### PR TITLE
fix(Async): don't use `vim.inspect` for non-table value errors

### DIFF
--- a/lua/___kit___/kit/Async/AsyncTask.lua
+++ b/lua/___kit___/kit/Async/AsyncTask.lua
@@ -52,7 +52,7 @@ AsyncTask.Status = {
 ---Handle unhandled rejection.
 ---@param err any
 function AsyncTask.on_unhandled_rejection(err)
-  error('AsyncTask.on_unhandled_rejection: ' .. vim.inspect(err), 2)
+  error('AsyncTask.on_unhandled_rejection: ' .. (type(err) == 'table' and vim.inspect(err) or tostring(err)), 2)
 end
 
 ---Return the value is AsyncTask or not.


### PR DESCRIPTION
The output of `vim.inspect("error string")` is too hard to read.