### PR TITLE
fix(LSP/Client): fix cancel function

### DIFF
--- a/lua/___kit___/kit/LSP/Client.lua
+++ b/lua/___kit___/kit/LSP/Client.lua
@@ -20,7 +20,7 @@ end
 ---@param params table
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:request(method, params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -33,8 +33,10 @@ function Client:request(method, params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -42,7 +44,7 @@ end
 ---@param params ___kit___.kit.LSP.ImplementationParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_implementation(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -55,8 +57,10 @@ function Client:textDocument_implementation(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -64,7 +68,7 @@ end
 ---@param params ___kit___.kit.LSP.TypeDefinitionParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_typeDefinition(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -77,8 +81,10 @@ function Client:textDocument_typeDefinition(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -86,7 +92,7 @@ end
 ---@param params nil
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_workspaceFolders(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -99,8 +105,10 @@ function Client:workspace_workspaceFolders(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -108,7 +116,7 @@ end
 ---@param params ___kit___.kit.LSP.ConfigurationParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_configuration(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -121,8 +129,10 @@ function Client:workspace_configuration(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -130,7 +140,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentColorParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_documentColor(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -143,8 +153,10 @@ function Client:textDocument_documentColor(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -152,7 +164,7 @@ end
 ---@param params ___kit___.kit.LSP.ColorPresentationParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_colorPresentation(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -165,8 +177,10 @@ function Client:textDocument_colorPresentation(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -174,7 +188,7 @@ end
 ---@param params ___kit___.kit.LSP.FoldingRangeParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_foldingRange(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -187,8 +201,10 @@ function Client:textDocument_foldingRange(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -196,7 +212,7 @@ end
 ---@param params nil
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_foldingRange_refresh(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -209,8 +225,10 @@ function Client:workspace_foldingRange_refresh(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -218,7 +236,7 @@ end
 ---@param params ___kit___.kit.LSP.DeclarationParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_declaration(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -231,8 +249,10 @@ function Client:textDocument_declaration(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -240,7 +260,7 @@ end
 ---@param params ___kit___.kit.LSP.SelectionRangeParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_selectionRange(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -253,8 +273,10 @@ function Client:textDocument_selectionRange(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -262,7 +284,7 @@ end
 ---@param params ___kit___.kit.LSP.WorkDoneProgressCreateParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:window_workDoneProgress_create(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -275,8 +297,10 @@ function Client:window_workDoneProgress_create(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -284,7 +308,7 @@ end
 ---@param params ___kit___.kit.LSP.CallHierarchyPrepareParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_prepareCallHierarchy(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -297,8 +321,10 @@ function Client:textDocument_prepareCallHierarchy(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -306,7 +332,7 @@ end
 ---@param params ___kit___.kit.LSP.CallHierarchyIncomingCallsParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:callHierarchy_incomingCalls(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -319,8 +345,10 @@ function Client:callHierarchy_incomingCalls(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -328,7 +356,7 @@ end
 ---@param params ___kit___.kit.LSP.CallHierarchyOutgoingCallsParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:callHierarchy_outgoingCalls(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -341,8 +369,10 @@ function Client:callHierarchy_outgoingCalls(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -350,7 +380,7 @@ end
 ---@param params ___kit___.kit.LSP.SemanticTokensParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_semanticTokens_full(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -363,8 +393,10 @@ function Client:textDocument_semanticTokens_full(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -372,7 +404,7 @@ end
 ---@param params ___kit___.kit.LSP.SemanticTokensDeltaParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_semanticTokens_full_delta(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -385,8 +417,10 @@ function Client:textDocument_semanticTokens_full_delta(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -394,7 +428,7 @@ end
 ---@param params ___kit___.kit.LSP.SemanticTokensRangeParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_semanticTokens_range(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -407,8 +441,10 @@ function Client:textDocument_semanticTokens_range(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -416,7 +452,7 @@ end
 ---@param params nil
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_semanticTokens_refresh(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -429,8 +465,10 @@ function Client:workspace_semanticTokens_refresh(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -438,7 +476,7 @@ end
 ---@param params ___kit___.kit.LSP.ShowDocumentParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:window_showDocument(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -451,8 +489,10 @@ function Client:window_showDocument(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -460,7 +500,7 @@ end
 ---@param params ___kit___.kit.LSP.LinkedEditingRangeParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_linkedEditingRange(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -473,8 +513,10 @@ function Client:textDocument_linkedEditingRange(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -482,7 +524,7 @@ end
 ---@param params ___kit___.kit.LSP.CreateFilesParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_willCreateFiles(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -495,8 +537,10 @@ function Client:workspace_willCreateFiles(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -504,7 +548,7 @@ end
 ---@param params ___kit___.kit.LSP.RenameFilesParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_willRenameFiles(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -517,8 +561,10 @@ function Client:workspace_willRenameFiles(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -526,7 +572,7 @@ end
 ---@param params ___kit___.kit.LSP.DeleteFilesParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_willDeleteFiles(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -539,8 +585,10 @@ function Client:workspace_willDeleteFiles(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -548,7 +596,7 @@ end
 ---@param params ___kit___.kit.LSP.MonikerParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_moniker(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -561,8 +609,10 @@ function Client:textDocument_moniker(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -570,7 +620,7 @@ end
 ---@param params ___kit___.kit.LSP.TypeHierarchyPrepareParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_prepareTypeHierarchy(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -583,8 +633,10 @@ function Client:textDocument_prepareTypeHierarchy(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -592,7 +644,7 @@ end
 ---@param params ___kit___.kit.LSP.TypeHierarchySupertypesParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:typeHierarchy_supertypes(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -605,8 +657,10 @@ function Client:typeHierarchy_supertypes(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -614,7 +668,7 @@ end
 ---@param params ___kit___.kit.LSP.TypeHierarchySubtypesParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:typeHierarchy_subtypes(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -627,8 +681,10 @@ function Client:typeHierarchy_subtypes(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -636,7 +692,7 @@ end
 ---@param params ___kit___.kit.LSP.InlineValueParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_inlineValue(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -649,8 +705,10 @@ function Client:textDocument_inlineValue(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -658,7 +716,7 @@ end
 ---@param params nil
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_inlineValue_refresh(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -671,8 +729,10 @@ function Client:workspace_inlineValue_refresh(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -680,7 +740,7 @@ end
 ---@param params ___kit___.kit.LSP.InlayHintParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_inlayHint(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -693,8 +753,10 @@ function Client:textDocument_inlayHint(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -702,7 +764,7 @@ end
 ---@param params ___kit___.kit.LSP.InlayHint
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:inlayHint_resolve(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -715,8 +777,10 @@ function Client:inlayHint_resolve(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -724,7 +788,7 @@ end
 ---@param params nil
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_inlayHint_refresh(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -737,8 +801,10 @@ function Client:workspace_inlayHint_refresh(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -746,7 +812,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentDiagnosticParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_diagnostic(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -759,8 +825,10 @@ function Client:textDocument_diagnostic(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -768,7 +836,7 @@ end
 ---@param params ___kit___.kit.LSP.WorkspaceDiagnosticParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_diagnostic(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -781,8 +849,10 @@ function Client:workspace_diagnostic(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -790,7 +860,7 @@ end
 ---@param params nil
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_diagnostic_refresh(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -803,8 +873,10 @@ function Client:workspace_diagnostic_refresh(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -812,7 +884,7 @@ end
 ---@param params ___kit___.kit.LSP.InlineCompletionParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_inlineCompletion(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -825,8 +897,58 @@ function Client:textDocument_inlineCompletion(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params ___kit___.kit.LSP.TextDocumentContentParams
+---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
+function Client:workspace_textDocumentContent(params)
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
+  ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
+  local task = AsyncTask.new(function(resolve, reject)
+    reject_ = reject
+    _, request_id = self.client:request('workspace/textDocumentContent', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+  end)
+  function task.cancel()
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
+  end
+  return task
+end
+
+---@param params ___kit___.kit.LSP.TextDocumentContentRefreshParams
+---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
+function Client:workspace_textDocumentContent_refresh(params)
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
+  ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
+  local task = AsyncTask.new(function(resolve, reject)
+    reject_ = reject
+    _, request_id = self.client:request('workspace/textDocumentContent/refresh', params, function(err, res)
+      if err then
+        reject(err)
+      else
+        resolve(res)
+      end
+    end)
+  end)
+  function task.cancel()
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -834,7 +956,7 @@ end
 ---@param params ___kit___.kit.LSP.RegistrationParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:client_registerCapability(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -847,8 +969,10 @@ function Client:client_registerCapability(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -856,7 +980,7 @@ end
 ---@param params ___kit___.kit.LSP.UnregistrationParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:client_unregisterCapability(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -869,8 +993,10 @@ function Client:client_unregisterCapability(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -878,7 +1004,7 @@ end
 ---@param params ___kit___.kit.LSP.InitializeParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:initialize(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -891,8 +1017,10 @@ function Client:initialize(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -900,7 +1028,7 @@ end
 ---@param params nil
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:shutdown(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -913,8 +1041,10 @@ function Client:shutdown(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -922,7 +1052,7 @@ end
 ---@param params ___kit___.kit.LSP.ShowMessageRequestParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:window_showMessageRequest(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -935,8 +1065,10 @@ function Client:window_showMessageRequest(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -944,7 +1076,7 @@ end
 ---@param params ___kit___.kit.LSP.WillSaveTextDocumentParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_willSaveWaitUntil(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -957,8 +1089,10 @@ function Client:textDocument_willSaveWaitUntil(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -966,7 +1100,7 @@ end
 ---@param params ___kit___.kit.LSP.CompletionParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_completion(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -979,8 +1113,10 @@ function Client:textDocument_completion(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -988,7 +1124,7 @@ end
 ---@param params ___kit___.kit.LSP.CompletionItem
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:completionItem_resolve(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1001,8 +1137,10 @@ function Client:completionItem_resolve(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1010,7 +1148,7 @@ end
 ---@param params ___kit___.kit.LSP.HoverParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_hover(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1023,8 +1161,10 @@ function Client:textDocument_hover(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1032,7 +1172,7 @@ end
 ---@param params ___kit___.kit.LSP.SignatureHelpParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_signatureHelp(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1045,8 +1185,10 @@ function Client:textDocument_signatureHelp(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1054,7 +1196,7 @@ end
 ---@param params ___kit___.kit.LSP.DefinitionParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_definition(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1067,8 +1209,10 @@ function Client:textDocument_definition(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1076,7 +1220,7 @@ end
 ---@param params ___kit___.kit.LSP.ReferenceParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_references(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1089,8 +1233,10 @@ function Client:textDocument_references(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1098,7 +1244,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentHighlightParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_documentHighlight(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1111,8 +1257,10 @@ function Client:textDocument_documentHighlight(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1120,7 +1268,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentSymbolParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_documentSymbol(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1133,8 +1281,10 @@ function Client:textDocument_documentSymbol(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1142,7 +1292,7 @@ end
 ---@param params ___kit___.kit.LSP.CodeActionParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_codeAction(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1155,8 +1305,10 @@ function Client:textDocument_codeAction(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1164,7 +1316,7 @@ end
 ---@param params ___kit___.kit.LSP.CodeAction
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:codeAction_resolve(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1177,8 +1329,10 @@ function Client:codeAction_resolve(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1186,7 +1340,7 @@ end
 ---@param params ___kit___.kit.LSP.WorkspaceSymbolParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_symbol(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1199,8 +1353,10 @@ function Client:workspace_symbol(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1208,7 +1364,7 @@ end
 ---@param params ___kit___.kit.LSP.WorkspaceSymbol
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspaceSymbol_resolve(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1221,8 +1377,10 @@ function Client:workspaceSymbol_resolve(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1230,7 +1388,7 @@ end
 ---@param params ___kit___.kit.LSP.CodeLensParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_codeLens(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1243,8 +1401,10 @@ function Client:textDocument_codeLens(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1252,7 +1412,7 @@ end
 ---@param params ___kit___.kit.LSP.CodeLens
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:codeLens_resolve(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1265,8 +1425,10 @@ function Client:codeLens_resolve(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1274,7 +1436,7 @@ end
 ---@param params nil
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_codeLens_refresh(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1287,8 +1449,10 @@ function Client:workspace_codeLens_refresh(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1296,7 +1460,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentLinkParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_documentLink(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1309,8 +1473,10 @@ function Client:textDocument_documentLink(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1318,7 +1484,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentLink
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:documentLink_resolve(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1331,8 +1497,10 @@ function Client:documentLink_resolve(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1340,7 +1508,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentFormattingParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_formatting(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1353,8 +1521,10 @@ function Client:textDocument_formatting(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1362,7 +1532,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentRangeFormattingParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_rangeFormatting(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1375,8 +1545,10 @@ function Client:textDocument_rangeFormatting(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1384,7 +1556,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentRangesFormattingParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_rangesFormatting(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1397,8 +1569,10 @@ function Client:textDocument_rangesFormatting(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1406,7 +1580,7 @@ end
 ---@param params ___kit___.kit.LSP.DocumentOnTypeFormattingParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_onTypeFormatting(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1419,8 +1593,10 @@ function Client:textDocument_onTypeFormatting(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1428,7 +1604,7 @@ end
 ---@param params ___kit___.kit.LSP.RenameParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_rename(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1441,8 +1617,10 @@ function Client:textDocument_rename(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1450,7 +1628,7 @@ end
 ---@param params ___kit___.kit.LSP.PrepareRenameParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:textDocument_prepareRename(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1463,8 +1641,10 @@ function Client:textDocument_prepareRename(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1472,7 +1652,7 @@ end
 ---@param params ___kit___.kit.LSP.ExecuteCommandParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_executeCommand(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1485,8 +1665,10 @@ function Client:workspace_executeCommand(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end
@@ -1494,7 +1676,7 @@ end
 ---@param params ___kit___.kit.LSP.ApplyWorkspaceEditParams
 ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
 function Client:workspace_applyEdit(params)
-  local that, _, request_id, reject_ = self, nil, nil, nil
+  local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
   ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
   local task = AsyncTask.new(function(resolve, reject)
     reject_ = reject
@@ -1507,8 +1689,10 @@ function Client:workspace_applyEdit(params)
     end)
   end)
   function task.cancel()
-    that.client:cancel_request(request_id)
-    reject_(LSP.ErrorCodes.RequestCancelled)
+    if request_id then
+      self.client:cancel_request(request_id)
+    end
+    reject_(LSP.LSPErrorCodes.RequestCancelled)
   end
   return task
 end

--- a/lua/___kit___/kit/LSP/init.lua
+++ b/lua/___kit___/kit/LSP/init.lua
@@ -353,6 +353,12 @@ LSP.CompletionTriggerKind = {
   TriggerForIncompleteCompletions = 3,
 }
 
+---@enum ___kit___.kit.LSP.ApplyKind
+LSP.ApplyKind = {
+  Replace = 1,
+  Merge = 2,
+}
+
 ---@enum ___kit___.kit.LSP.SignatureHelpTriggerKind
 LSP.SignatureHelpTriggerKind = {
   Invoked = 1,
@@ -679,6 +685,17 @@ LSP.TokenFormat = {
 
 ---@class ___kit___.kit.LSP.InlineCompletionRegistrationOptions : ___kit___.kit.LSP.InlineCompletionOptions, ___kit___.kit.LSP.TextDocumentRegistrationOptions, ___kit___.kit.LSP.StaticRegistrationOptions
 
+---@class ___kit___.kit.LSP.TextDocumentContentParams
+---@field public uri string The uri of the text document.
+
+---@class ___kit___.kit.LSP.TextDocumentContentResult
+---@field public text string The text content of the text document. Please note, that the content of<br>any subsequent open notifications for the text document might differ<br>from the returned content due to whitespace and line ending<br>normalizations done on the client
+
+---@class ___kit___.kit.LSP.TextDocumentContentRegistrationOptions : ___kit___.kit.LSP.TextDocumentContentOptions, ___kit___.kit.LSP.StaticRegistrationOptions
+
+---@class ___kit___.kit.LSP.TextDocumentContentRefreshParams
+---@field public uri string The uri of the text document to refresh.
+
 ---@class ___kit___.kit.LSP.RegistrationParams
 ---@field public registrations ___kit___.kit.LSP.Registration[]
 
@@ -757,7 +774,7 @@ LSP.TokenFormat = {
 ---@field public diagnostics ___kit___.kit.LSP.Diagnostic[] An array of diagnostic information items.
 
 ---@class ___kit___.kit.LSP.CompletionParams : ___kit___.kit.LSP.TextDocumentPositionParams, ___kit___.kit.LSP.WorkDoneProgressParams, ___kit___.kit.LSP.PartialResultParams
----@field public context? ___kit___.kit.LSP.CompletionContext The completion context. This is only available if the client specifies<br>to send this using the client capability `textDocument.completion.contextSupport === true`
+---@field public context? ___kit___.kit.LSP.CompletionContext The completion context. This is only available it the client specifies<br>to send this using the client capability `textDocument.completion.contextSupport === true`
 
 ---@class ___kit___.kit.LSP.CompletionItem
 ---@field public label string The label of this completion item.<br><br>The label property is also by default the text that<br>is inserted when selecting this completion.<br><br>If label details are provided the label itself should<br>be an unqualified name of the completion item.
@@ -782,7 +799,8 @@ LSP.TokenFormat = {
 
 ---@class ___kit___.kit.LSP.CompletionList
 ---@field public isIncomplete boolean This list it not complete. Further typing results in recomputing this list.<br><br>Recomputed lists have all their items replaced (not appended) in the<br>incomplete completion sessions.
----@field public itemDefaults? ___kit___.kit.LSP.CompletionItemDefaults In many cases the items of an actual completion result share the same<br>value for properties like `commitCharacters` or the range of a text<br>edit. A completion list can therefore define item defaults which will<br>be used if a completion item itself doesn't specify the value.<br><br>If a completion list specifies a default value and a completion item<br>also specifies a corresponding value the one from the item is used.<br><br>Servers are only allowed to return default values if the client<br>signals support for this via the `completionList.itemDefaults`<br>capability.<br><br>@since 3.17.0
+---@field public itemDefaults? ___kit___.kit.LSP.CompletionItemDefaults In many cases the items of an actual completion result share the same<br>value for properties like `commitCharacters` or the range of a text<br>edit. A completion list can therefore define item defaults which will<br>be used if a completion item itself doesn't specify the value.<br><br>If a completion list specifies a default value and a completion item<br>also specifies a corresponding value, the rules for combining these are<br>defined by `applyKinds` (if the client supports it), defaulting to<br>ApplyKind.Replace.<br><br>Servers are only allowed to return default values if the client<br>signals support for this via the `completionList.itemDefaults`<br>capability.<br><br>@since 3.17.0
+---@field public applyKind? ___kit___.kit.LSP.CompletionItemApplyKinds Specifies how fields from a completion item should be combined with those<br>from `completionList.itemDefaults`.<br><br>If unspecified, all fields will be treated as ApplyKind.Replace.<br><br>If a field's value is ApplyKind.Replace, the value from a completion item<br>(if provided and not `null`) will always be used instead of the value<br>from `completionItem.itemDefaults`.<br><br>If a field's value is ApplyKind.Merge, the values will be merged using<br>the rules defined against each field below.<br><br>Servers are only allowed to return `applyKind` if the client<br>signals support for this via the `completionList.applyKindSupport`<br>capability.<br><br>@since 3.18.0
 ---@field public items ___kit___.kit.LSP.CompletionItem[] The completion items.
 
 ---@class ___kit___.kit.LSP.CompletionRegistrationOptions : ___kit___.kit.LSP.TextDocumentRegistrationOptions, ___kit___.kit.LSP.CompletionOptions
@@ -951,13 +969,13 @@ LSP.TokenFormat = {
 ---@field public title string Mandatory title of the progress operation. Used to briefly inform about<br>the kind of operation being performed.<br><br>Examples: "Indexing" or "Linking dependencies".
 ---@field public cancellable? boolean Controls if a cancel button should show to allow the user to cancel the<br>long running operation. Clients that don't support cancellation are allowed<br>to ignore the setting.
 ---@field public message? string Optional, more detailed associated progress message. Contains<br>complementary information to the `title`.<br><br>Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".<br>If unset, the previous progress message (if any) is still valid.
----@field public percentage? integer Optional progress percentage to display (value 100 is considered 100%).<br>If not provided infinite progress is assumed and clients are allowed<br>to ignore the `percentage` value in subsequent report notifications.<br><br>The value should be steadily rising. Clients are free to ignore values<br>that are not following this rule. The value range is [0, 100].
+---@field public percentage? integer Optional progress percentage to display (value 100 is considered 100%).<br>If not provided infinite progress is assumed and clients are allowed<br>to ignore the `percentage` value in subsequent in report notifications.<br><br>The value should be steadily rising. Clients are free to ignore values<br>that are not following this rule. The value range is [0, 100].
 
 ---@class ___kit___.kit.LSP.WorkDoneProgressReport
 ---@field public kind "report"
 ---@field public cancellable? boolean Controls enablement state of a cancel button.<br><br>Clients that don't support cancellation or don't support controlling the button's<br>enablement state are allowed to ignore the property.
 ---@field public message? string Optional, more detailed associated progress message. Contains<br>complementary information to the `title`.<br><br>Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".<br>If unset, the previous progress message (if any) is still valid.
----@field public percentage? integer Optional progress percentage to display (value 100 is considered 100%).<br>If not provided infinite progress is assumed and clients are allowed<br>to ignore the `percentage` value in subsequent report notifications.<br><br>The value should be steadily rising. Clients are free to ignore values<br>that are not following this rule. The value range is [0, 100].
+---@field public percentage? integer Optional progress percentage to display (value 100 is considered 100%).<br>If not provided infinite progress is assumed and clients are allowed<br>to ignore the `percentage` value in subsequent in report notifications.<br><br>The value should be steadily rising. Clients are free to ignore values<br>that are not following this rule. The value range is [0, 100]
 
 ---@class ___kit___.kit.LSP.WorkDoneProgressEnd
 ---@field public kind "end"
@@ -1028,8 +1046,8 @@ LSP.TokenFormat = {
 ---@class ___kit___.kit.LSP.DeclarationOptions : ___kit___.kit.LSP.WorkDoneProgressOptions
 
 ---@class ___kit___.kit.LSP.Position
----@field public line integer Line position in a document (zero-based).<br><br>If a line number is greater than the number of lines in a document, it defaults back to the number of lines in the document.<br>If a line number is negative, it defaults to 0.
----@field public character integer Character offset on a line in a document (zero-based).<br><br>The meaning of this offset is determined by the negotiated<br>`PositionEncodingKind`.<br><br>If the character value is greater than the line length it defaults back to the<br>line length.
+---@field public line integer Line position in a document (zero-based).
+---@field public character integer Character offset on a line in a document (zero-based).<br><br>The meaning of this offset is determined by the negotiated<br>`PositionEncodingKind`.
 
 ---@class ___kit___.kit.LSP.SelectionRangeOptions : ___kit___.kit.LSP.WorkDoneProgressOptions
 
@@ -1184,6 +1202,9 @@ LSP.TokenFormat = {
 
 ---@class ___kit___.kit.LSP.InlineCompletionOptions : ___kit___.kit.LSP.WorkDoneProgressOptions
 
+---@class ___kit___.kit.LSP.TextDocumentContentOptions
+---@field public schemes string[] The schemes for which the server provides content.
+
 ---@class ___kit___.kit.LSP.Registration
 ---@field public id string The id used to register the request. The id can be used to deregister<br>the request again.
 ---@field public method string The method / capability to register for.
@@ -1292,6 +1313,10 @@ LSP.TokenFormat = {
 ---@field public insertTextFormat? ___kit___.kit.LSP.InsertTextFormat A default insert text format.<br><br>@since 3.17.0
 ---@field public insertTextMode? ___kit___.kit.LSP.InsertTextMode A default insert text mode.<br><br>@since 3.17.0
 ---@field public data? ___kit___.kit.LSP.LSPAny A default data value.<br><br>@since 3.17.0
+
+---@class ___kit___.kit.LSP.CompletionItemApplyKinds
+---@field public commitCharacters? ___kit___.kit.LSP.ApplyKind Specifies whether commitCharacters on a completion will replace or be<br>merged with those in `completionList.itemDefaults.commitCharacters`.<br><br>If ApplyKind.Replace, the commit characters from the completion item will<br>always be used unless not provided, in which case those from<br>`completionList.itemDefaults.commitCharacters` will be used. An<br>empty list can be used if a completion item does not have any commit<br>characters and also should not use those from<br>`completionList.itemDefaults.commitCharacters`.<br><br>If ApplyKind.Merge the commitCharacters for the completion will be the<br>union of all values in both `completionList.itemDefaults.commitCharacters`<br>and the completion's own `commitCharacters`.<br><br>@since 3.18.0
+---@field public data? ___kit___.kit.LSP.ApplyKind Specifies whether the `data` field on a completion will replace or<br>be merged with data from `completionList.itemDefaults.data`.<br><br>If ApplyKind.Replace, the data from the completion item will be used if<br>provided (and not `null`), otherwise<br>`completionList.itemDefaults.data` will be used. An empty object can<br>be used if a completion item does not have any data but also should<br>not use the value from `completionList.itemDefaults.data`.<br><br>If ApplyKind.Merge, a shallow merge will be performed between<br>`completionList.itemDefaults.data` and the completion's own data<br>using the following rules:<br><br>- If a completion's `data` field is not provided (or `null`), the<br>  entire `data` field from `completionList.itemDefaults.data` will be<br>  used as-is.<br>- If a completion's `data` field is provided, each field will<br>  overwrite the field of the same name in<br>  `completionList.itemDefaults.data` but no merging of nested fields<br>  within that value will occur.<br><br>@since 3.18.0
 
 ---@class ___kit___.kit.LSP.CompletionOptions : ___kit___.kit.LSP.WorkDoneProgressOptions
 ---@field public triggerCharacters? string[] Most tools trigger completion request automatically without explicitly requesting<br>it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user<br>starts to type an identifier. For example if the user types `c` in a JavaScript file<br>code complete will automatically pop up present `console` besides others as a<br>completion item. Characters that make up identifiers don't need to be listed here.<br><br>If code complete should automatically be trigger on characters not being valid inside<br>an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
@@ -1427,7 +1452,7 @@ LSP.TokenFormat = {
 ---@field public ignoreIfNotExists? boolean Ignore the operation if the file doesn't exist.
 
 ---@class ___kit___.kit.LSP.FileOperationPattern
----@field public glob string The glob pattern to match. Glob patterns can have the following syntax:<br>- `*` to match one or more characters in a path segment<br>- `?` to match on one character in a path segment<br>- `**` to match any number of path segments, including none<br>- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)<br>- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)<br>- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+---@field public glob string The glob pattern to match. Glob patterns can have the following syntax:<br>- `*` to match zero or more characters in a path segment<br>- `?` to match on one character in a path segment<br>- `**` to match any number of path segments, including none<br>- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)<br>- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)<br>- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
 ---@field public matches? ___kit___.kit.LSP.FileOperationPatternKind Whether to match files or folders with this pattern.<br><br>Matches both if undefined.
 ---@field public options? ___kit___.kit.LSP.FileOperationPatternOptions Additional options used during matching.
 
@@ -1484,6 +1509,7 @@ LSP.TokenFormat = {
 ---@class ___kit___.kit.LSP.WorkspaceOptions
 ---@field public workspaceFolders? ___kit___.kit.LSP.WorkspaceFoldersServerCapabilities The server supports workspace folder.<br><br>@since 3.6.0
 ---@field public fileOperations? ___kit___.kit.LSP.FileOperationOptions The server is interested in notifications/requests for operations on files.<br><br>@since 3.16.0
+---@field public textDocumentContent? (___kit___.kit.LSP.TextDocumentContentOptions | ___kit___.kit.LSP.TextDocumentContentRegistrationOptions) The server supports the `workspace/textDocumentContent` request.<br><br>@since 3.18.0<br>@proposed
 
 ---@class ___kit___.kit.LSP.TextDocumentContentChangePartial
 ---@field public range ___kit___.kit.LSP.Range The range of the document that changed.
@@ -1558,9 +1584,11 @@ LSP.TokenFormat = {
 ---@field public inlayHint? ___kit___.kit.LSP.InlayHintWorkspaceClientCapabilities Capabilities specific to the inlay hint requests scoped to the<br>workspace.<br><br>@since 3.17.0.
 ---@field public diagnostics? ___kit___.kit.LSP.DiagnosticWorkspaceClientCapabilities Capabilities specific to the diagnostic requests scoped to the<br>workspace.<br><br>@since 3.17.0.
 ---@field public foldingRange? ___kit___.kit.LSP.FoldingRangeWorkspaceClientCapabilities Capabilities specific to the folding range requests scoped to the workspace.<br><br>@since 3.18.0<br>@proposed
+---@field public textDocumentContent? ___kit___.kit.LSP.TextDocumentContentClientCapabilities Capabilities specific to the `workspace/textDocumentContent` request.<br><br>@since 3.18.0<br>@proposed
 
 ---@class ___kit___.kit.LSP.TextDocumentClientCapabilities
 ---@field public synchronization? ___kit___.kit.LSP.TextDocumentSyncClientCapabilities Defines which synchronization capabilities the client supports.
+---@field public filters? ___kit___.kit.LSP.TextDocumentFilterClientCapabilities Defines which filters the client supports.<br><br>@since 3.18.0
 ---@field public completion? ___kit___.kit.LSP.CompletionClientCapabilities Capabilities specific to the `textDocument/completion` request.
 ---@field public hover? ___kit___.kit.LSP.HoverClientCapabilities Capabilities specific to the `textDocument/hover` request.
 ---@field public signatureHelp? ___kit___.kit.LSP.SignatureHelpClientCapabilities Capabilities specific to the `textDocument/signatureHelp` request.
@@ -1625,17 +1653,17 @@ LSP.TokenFormat = {
 ---@class ___kit___.kit.LSP.TextDocumentFilterLanguage
 ---@field public language string A language id, like `typescript`.
 ---@field public scheme? string A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
----@field public pattern? ___kit___.kit.LSP.GlobPattern A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.<br><br>@since 3.18.0 - support for relative patterns.
+---@field public pattern? ___kit___.kit.LSP.GlobPattern A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.<br><br>@since 3.18.0 - support for relative patterns. Whether clients support<br>relative patterns depends on the client capability<br>`textDocuments.filters.relativePatternSupport`.
 
 ---@class ___kit___.kit.LSP.TextDocumentFilterScheme
 ---@field public language? string A language id, like `typescript`.
 ---@field public scheme string A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
----@field public pattern? ___kit___.kit.LSP.GlobPattern A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.<br><br>@since 3.18.0 - support for relative patterns.
+---@field public pattern? ___kit___.kit.LSP.GlobPattern A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.<br><br>@since 3.18.0 - support for relative patterns. Whether clients support<br>relative patterns depends on the client capability<br>`textDocuments.filters.relativePatternSupport`.
 
 ---@class ___kit___.kit.LSP.TextDocumentFilterPattern
 ---@field public language? string A language id, like `typescript`.
 ---@field public scheme? string A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
----@field public pattern ___kit___.kit.LSP.GlobPattern A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.<br><br>@since 3.18.0 - support for relative patterns.
+---@field public pattern ___kit___.kit.LSP.GlobPattern A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.<br><br>@since 3.18.0 - support for relative patterns. Whether clients support<br>relative patterns depends on the client capability<br>`textDocuments.filters.relativePatternSupport`.
 
 ---@class ___kit___.kit.LSP.NotebookDocumentFilterNotebookType
 ---@field public notebookType string The type of the enclosing notebook.
@@ -1709,11 +1737,17 @@ LSP.TokenFormat = {
 ---@class ___kit___.kit.LSP.FoldingRangeWorkspaceClientCapabilities
 ---@field public refreshSupport? boolean Whether the client implementation supports a refresh request sent from the<br>server to the client.<br><br>Note that this event is global and will force the client to refresh all<br>folding ranges currently shown. It should be used with absolute care and is<br>useful for situation where a server for example detects a project wide<br>change that requires such a calculation.<br><br>@since 3.18.0<br>@proposed
 
+---@class ___kit___.kit.LSP.TextDocumentContentClientCapabilities
+---@field public dynamicRegistration? boolean Text document content provider supports dynamic registration.
+
 ---@class ___kit___.kit.LSP.TextDocumentSyncClientCapabilities
 ---@field public dynamicRegistration? boolean Whether text document synchronization supports dynamic registration.
 ---@field public willSave? boolean The client supports sending will save notifications.
 ---@field public willSaveWaitUntil? boolean The client supports sending a will save request and<br>waits for a response providing text edits which will<br>be applied to the document before it is saved.
 ---@field public didSave? boolean The client supports did save notifications.
+
+---@class ___kit___.kit.LSP.TextDocumentFilterClientCapabilities
+---@field public relativePatternSupport? boolean The client supports Relative Patterns.<br><br>@since 3.18.0
 
 ---@class ___kit___.kit.LSP.CompletionClientCapabilities
 ---@field public dynamicRegistration? boolean Whether completion supports dynamic registration.
@@ -1771,9 +1805,6 @@ LSP.TokenFormat = {
 ---@field public honorsChangeAnnotations? boolean Whether the client honors the change annotations in<br>text edits and resource operations returned via the<br>`CodeAction#edit` property by for example presenting<br>the workspace edit in the user interface and asking<br>for confirmation.<br><br>@since 3.16.0
 ---@field public documentationSupport? boolean Whether the client supports documentation for a class of<br>code actions.<br><br>@since 3.18.0<br>@proposed
 ---@field public tagSupport? ___kit___.kit.LSP.CodeActionTagOptions Client supports the tag property on a code action. Clients<br>supporting tags have to handle unknown tags gracefully.<br><br>@since 3.18.0 - proposed
-
----@class ___kit___.kit.LSP.CodeActionTagOptions
----@field public valueSet ___kit___.kit.LSP.CodeActionTag[] The tags supported by the client.
 
 ---@class ___kit___.kit.LSP.CodeLensClientCapabilities
 ---@field public dynamicRegistration? boolean Whether code lens supports dynamic registration.
@@ -1904,6 +1935,7 @@ LSP.TokenFormat = {
 
 ---@class ___kit___.kit.LSP.CompletionListCapabilities
 ---@field public itemDefaults? string[] The client supports the following itemDefaults on<br>a completion list.<br><br>The value lists the supported property names of the<br>`CompletionList.itemDefaults` object. If omitted<br>no properties are supported.<br><br>@since 3.17.0
+---@field public applyKindSupport? boolean Specifies whether the client supports `CompletionList.applyKind` to<br>indicate how supported values from `completionList.itemDefaults`<br>and `completion` will be combined.<br><br>If a client supports `applyKind` it must support it for all fields<br>that it supports that are listed in `CompletionList.applyKind`. This<br>means when clients add support for new/future fields in completion<br>items the MUST also support merge for them if those fields are<br>defined in `CompletionList.applyKind`.<br><br>@since 3.18.0
 
 ---@class ___kit___.kit.LSP.ClientSignatureInformationOptions
 ---@field public documentationFormat? ___kit___.kit.LSP.MarkupKind[] Client supports the following content formats for the documentation<br>property. The order describes the preferred format of the client.
@@ -1916,6 +1948,9 @@ LSP.TokenFormat = {
 
 ---@class ___kit___.kit.LSP.ClientCodeActionResolveOptions
 ---@field public properties string[] The properties that a client can resolve lazily.
+
+---@class ___kit___.kit.LSP.CodeActionTagOptions
+---@field public valueSet ___kit___.kit.LSP.CodeActionTag[] The tags supported by the client.
 
 ---@class ___kit___.kit.LSP.ClientCodeLensResolveOptions
 ---@field public properties string[] The properties that a client can resolve lazily.
@@ -2034,6 +2069,10 @@ LSP.TokenFormat = {
 ---@alias ___kit___.kit.LSP.WorkspaceDiagnosticRefreshResponse nil
 
 ---@alias ___kit___.kit.LSP.TextDocumentInlineCompletionResponse (___kit___.kit.LSP.InlineCompletionList | ___kit___.kit.LSP.InlineCompletionItem[] | nil)
+
+---@alias ___kit___.kit.LSP.WorkspaceTextDocumentContentResponse ___kit___.kit.LSP.TextDocumentContentResult
+
+---@alias ___kit___.kit.LSP.WorkspaceTextDocumentContentRefreshResponse nil
 
 ---@alias ___kit___.kit.LSP.ClientRegisterCapabilityResponse nil
 

--- a/script/lsp/generate-client.ts
+++ b/script/lsp/generate-client.ts
@@ -27,7 +27,7 @@ import metaModel from '../../tmp/language-server-protocol/_specifications/lsp/3.
     ---@param params table
     ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
     function Client:request(method, params)
-      local that, _, request_id, reject_ = self, nil, nil, nil
+      local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
       ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
       local task = AsyncTask.new(function(resolve, reject)
         reject_ = reject
@@ -40,8 +40,10 @@ import metaModel from '../../tmp/language-server-protocol/_specifications/lsp/3.
         end)
       end)
       function task.cancel()
-        that.client:cancel_request(request_id)
-        reject_(LSP.ErrorCodes.RequestCancelled)
+        if request_id then
+          self.client:cancel_request(request_id)
+        end
+        reject_(LSP.LSPErrorCodes.RequestCancelled)
       end
       return task
     end
@@ -59,7 +61,7 @@ import metaModel from '../../tmp/language-server-protocol/_specifications/lsp/3.
             ${params}
             ---@return ___kit___.kit.Async.AsyncTask|{cancel: fun()}
             function Client:${request.method.replace(/\//g, '_')}(params)
-              local that, _, request_id, reject_ = self, nil, nil, nil
+              local _, request_id, reject_ ---@type any, integer?, fun(err: any?)
               ---@type ___kit___.kit.Async.AsyncTask|{cancel: fun()}
               local task = AsyncTask.new(function(resolve, reject)
                 reject_ = reject
@@ -72,8 +74,10 @@ import metaModel from '../../tmp/language-server-protocol/_specifications/lsp/3.
                 end)
               end)
               function task.cancel()
-                that.client:cancel_request(request_id)
-                reject_(LSP.ErrorCodes.RequestCancelled)
+                if request_id then
+                  self.client:cancel_request(request_id)
+                end
+                reject_(LSP.LSPErrorCodes.RequestCancelled)
               end
               return task
             end


### PR DESCRIPTION
- use `LSPErrorCodes.RequestCancelled` instead of `ErrorCodes.RequestCancelled`
- do not call `cancel_request()` if the request was immediately failed